### PR TITLE
Add proper logout action

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,30 +2,15 @@
   "version": "0.2.0",
   "configurations": [
     {
+      "name": "Debug CRA Tests",
       "type": "node",
       "request": "launch",
-      "name": "Jest All",
-      "program": "${workspaceFolder}/node_modules/.bin/jest",
-      "args": ["--runInBand"],
+      "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/react-scripts",
+      "args": ["test", "--runInBand", "--no-cache", "--no-watch"],
+      "cwd": "${workspaceRoot}",
+      "protocol": "inspector",
       "console": "integratedTerminal",
-      "internalConsoleOptions": "neverOpen",
-      "disableOptimisticBPs": true,
-      "windows": {
-        "program": "${workspaceFolder}/node_modules/jest/bin/jest",
-      }
-    },
-    {
-      "type": "node",
-      "request": "launch",
-      "name": "Jest Current File",
-      "program": "${workspaceFolder}/node_modules/.bin/jest",
-      "args": ["${relativeFile}"],
-      "console": "integratedTerminal",
-      "internalConsoleOptions": "neverOpen",
-      "disableOptimisticBPs": true,
-      "windows": {
-        "program": "${workspaceFolder}/node_modules/jest/bin/jest",
-      }
+      "internalConsoleOptions": "neverOpen"
     }
   ]
 }

--- a/flow-typed/myLibDef.js
+++ b/flow-typed/myLibDef.js
@@ -1,6 +1,7 @@
 declare type SessionHandler = {
-  getUser(): Promise<any>,
+  getUser(): Promise<Object>,
   login(): void,
+  logout(username: string): Promise<boolean>,
   signup(): void,
 };
 

--- a/src/__tests__/DebtcollectiveHeader.spec.js
+++ b/src/__tests__/DebtcollectiveHeader.spec.js
@@ -71,9 +71,7 @@ describe("<DebtcollectiveHeader />", () => {
       expect(getByText(/account/i).getAttribute("href")).toMatchInlineSnapshot(
         "\"http://localhost:3000/u/johndoe/preferences/account\""
       );
-      expect(getByText(/logout/i).getAttribute("href")).toMatchInlineSnapshot(
-        "\"http://localhost:3000/logout\""
-      );
+      expect(getByText(/logout/i)).toBeTruthy();
     });
   });
 });

--- a/src/common/DiscourseService.js
+++ b/src/common/DiscourseService.js
@@ -70,6 +70,18 @@ const get = async (url: string, options: Object = {}) => {
   return result;
 };
 
+const reqDelete = async (url: string, options: Object = {}) => {
+  await refreshToken();
+
+  const response = await fetch(`${getBaseUrl()}/${url}`, {
+    ...requestBaseOptions({ method: "delete" }),
+    ...options,
+  });
+  const result = await parseResponseToJSON(response);
+
+  return result;
+};
+
 const goTo = (path: string): void => {
   window.open(`${getBaseUrl()}/${path}`, "_blank");
 };
@@ -80,6 +92,7 @@ export default {
   getToken,
   goTo,
   refreshToken,
+  reqDelete,
   requestBaseOptions,
   resetToken,
   setToken,

--- a/src/common/__tests__/DiscourseService.spec.js
+++ b/src/common/__tests__/DiscourseService.spec.js
@@ -67,10 +67,20 @@ describe("DiscourseService", () => {
       const { data } = response;
 
       expect(data).toEqual(valueToMatch);
-      expect(window.fetch).toHaveBeenNthCalledWith(1, `${baseUrl}/foo.json`, {
-        credentials: "include",
-        headers: { Accept: "application/json" },
-      });
+      expect(window.fetch).toHaveBeenCalledTimes(1);
+      expect(window.fetch.mock.calls[0]).toMatchInlineSnapshot(
+        `
+Array [
+  "http://localhost:3000/foo.json",
+  Object {
+    "credentials": "include",
+    "headers": Object {
+      "Accept": "application/json",
+    },
+  },
+]
+`
+      );
     });
 
     it("allows to send DELETE request to a given path", async () => {
@@ -88,11 +98,14 @@ describe("DiscourseService", () => {
 
       expect(response).toEqual("foo deleted");
       expect(window.fetch).toHaveBeenCalledTimes(2);
-      expect(window.fetch).toHaveBeenNthCalledWith(
-        1,
-        `${baseUrl}/session/csrf.json`,
-        { credentials: "include" }
-      );
+      expect(window.fetch.mock.calls[0]).toMatchInlineSnapshot(`
+Array [
+  "http://localhost:3000/session/csrf.json",
+  Object {
+    "credentials": "include",
+  },
+]
+`);
       expect(window.fetch.mock.calls[1]).toMatchInlineSnapshot(`
 Array [
   "http://localhost:3000/foo.json",

--- a/src/common/__tests__/DiscourseService.spec.js
+++ b/src/common/__tests__/DiscourseService.spec.js
@@ -104,10 +104,42 @@ describe("DiscourseService", () => {
       });
     });
 
-    it("allows to send POST request to a given path", () => {});
+    it("allows to send DELETE request to a given path", async () => {
+      window.fetch = jest
+        .fn()
+        .mockReturnValueOnce({
+          json: () => Promise.resolve({ csrf: "token-fake-fixed-value" }),
+          ok: true,
+        })
+        .mockReturnValueOnce(
+          Promise.resolve({ json: () => "foo deleted", ok: true })
+        );
 
-    it("allows to send PUT request to a given path", () => {});
+      const response = await DiscourseService.reqDelete("foo.json");
 
-    it("allows to send DELETE request to a given path", () => {});
+      expect(response).toEqual("foo deleted");
+      expect(window.fetch).toHaveBeenCalledTimes(2);
+      expect(window.fetch).toHaveBeenNthCalledWith(
+        1,
+        `${baseUrl}/session/csrf.json`
+      );
+      expect(window.fetch.mock.calls[1]).toMatchInlineSnapshot(`
+Array [
+  "http://localhost:3000/foo.json",
+  Object {
+    "credentials": "include",
+    "headers": Object {
+      "Accept": "application/json",
+      "X-CSRF-Token": "token-fake-fixed-value",
+    },
+    "method": "delete",
+  },
+]
+`);
+    });
+
+    xit("allows to send POST request to a given path", () => {});
+
+    xit("allows to send PUT request to a given path", () => {});
   });
 });

--- a/src/common/__tests__/DiscourseService.spec.js
+++ b/src/common/__tests__/DiscourseService.spec.js
@@ -12,19 +12,14 @@ describe("DiscourseService", () => {
     expect(window.open).toHaveBeenCalledWith(`${baseUrl}/foo`, "_blank");
   });
 
-  describe("refreshToken", () => {
+  describe("getCSRFToken", () => {
     const tokenResponse = {
       json: () => Promise.resolve({ csrf: faker.random.uuid() }),
       ok: true,
     };
 
-    const randomResponse = {
-      json: () => Promise.resolve({ data: faker.random.objectElement() }),
-      ok: true,
-    };
-
     beforeEach(() => {
-      DiscourseService.resetToken();
+      DiscourseService.resetCSRFToken();
       jest.clearAllMocks();
     });
 
@@ -33,24 +28,9 @@ describe("DiscourseService", () => {
         .spyOn(window, "fetch")
         .mockImplementationOnce(() => Promise.resolve(tokenResponse));
 
-      const initialToken = DiscourseService.getToken();
-      const refreshedToken = await DiscourseService.refreshToken();
+      const token = await DiscourseService.getCSRFToken();
 
-      expect(initialToken).toBe("");
-      expect(DiscourseService.getToken()).toEqual(refreshedToken);
-    });
-
-    it("gets called before every XHR request", async () => {
-      jest
-        .spyOn(window, "fetch")
-        .mockImplementationOnce(() => Promise.resolve(tokenResponse))
-        .mockImplementationOnce(() => Promise.resolve(randomResponse));
-
-      const initialToken = DiscourseService.getToken();
-      await DiscourseService.get("/foo.json");
-
-      expect(initialToken).toBe("");
-      expect(DiscourseService.getToken().length).toBeGreaterThan(1);
+      expect(token).not.toBeFalsy();
     });
 
     it("returns the saved token if available", async () => {
@@ -58,49 +38,38 @@ describe("DiscourseService", () => {
         .spyOn(window, "fetch")
         .mockImplementationOnce(() => Promise.resolve(tokenResponse));
 
-      const refreshedToken = await DiscourseService.refreshToken();
-      const nextToken = await DiscourseService.refreshToken();
+      const token = await DiscourseService.getCSRFToken();
+      const nextToken = await DiscourseService.getCSRFToken();
 
-      expect(refreshedToken).toEqual(nextToken);
+      expect(token).toEqual(nextToken);
       expect(window.fetch).toBeCalledTimes(1);
     });
   });
 
   describe("XHR requests", () => {
     const valueToMatch = faker.random.word();
-    const tokenToMatch = faker.random.uuid();
-    const tokenResponse = {
-      json: () => Promise.resolve({ csrf: tokenToMatch }),
-      ok: true,
-    };
-
     const randomResponse = {
       json: () => Promise.resolve({ data: valueToMatch }),
       ok: true,
     };
 
     beforeEach(() => {
-      DiscourseService.resetToken();
+      DiscourseService.resetCSRFToken();
       jest.clearAllMocks();
     });
 
     it("allows send GET request to a given path returning parsed response", async () => {
       window.fetch = jest
         .fn()
-        .mockReturnValueOnce(Promise.resolve(tokenResponse))
         .mockReturnValueOnce(Promise.resolve(randomResponse));
 
       const response = await DiscourseService.get("foo.json");
       const { data } = response;
 
       expect(data).toEqual(valueToMatch);
-      expect(window.fetch).toHaveBeenNthCalledWith(
-        1,
-        `${baseUrl}/session/csrf.json`
-      );
-      expect(window.fetch).toHaveBeenNthCalledWith(2, `${baseUrl}/foo.json`, {
+      expect(window.fetch).toHaveBeenNthCalledWith(1, `${baseUrl}/foo.json`, {
         credentials: "include",
-        headers: { Accept: "application/json", "X-CSRF-Token": tokenToMatch },
+        headers: { Accept: "application/json" },
       });
     });
 
@@ -121,7 +90,8 @@ describe("DiscourseService", () => {
       expect(window.fetch).toHaveBeenCalledTimes(2);
       expect(window.fetch).toHaveBeenNthCalledWith(
         1,
-        `${baseUrl}/session/csrf.json`
+        `${baseUrl}/session/csrf.json`,
+        { credentials: "include" }
       );
       expect(window.fetch.mock.calls[1]).toMatchInlineSnapshot(`
 Array [

--- a/src/profile/UserAvatarDropdown.js
+++ b/src/profile/UserAvatarDropdown.js
@@ -72,8 +72,8 @@ const Dropdown = ({ anchorEl, handleClose, onClickLogout, user }) => (
         {translate("profile.actions.account")}
       </Link>
     </MenuItem>
-    <MenuItem onClick={onClickLogout}>
-      {translate("profile.actions.logout")}
+    <MenuItem aria-labelledby="btn-logout" onClick={onClickLogout}>
+      <Link underline="none">{translate("profile.actions.logout")}</Link>
     </MenuItem>
   </Menu>
 );

--- a/src/profile/UserAvatarDropdown.js
+++ b/src/profile/UserAvatarDropdown.js
@@ -4,6 +4,7 @@ import * as React from "react";
 import AccountCircle from "@material-ui/icons/AccountCircle";
 import IconButton from "@material-ui/core/IconButton";
 import Menu from "@material-ui/core/Menu";
+import SessionService from "../session/SessionService";
 import styled from "styled-components";
 import { translate } from "../locales";
 import { interpolateAvatarUrl, prependDiscourseUrl } from "../common/helpers";
@@ -46,7 +47,7 @@ const MenuItem = styled(MUMenuItem)`
   }
 `;
 
-const Dropdown = ({ anchorEl, handleClose, user }) => (
+const Dropdown = ({ anchorEl, handleClose, onClickLogout, user }) => (
   <Menu
     id={DROPDOWN_NAME}
     anchorEl={anchorEl}
@@ -71,20 +72,15 @@ const Dropdown = ({ anchorEl, handleClose, user }) => (
         {translate("profile.actions.account")}
       </Link>
     </MenuItem>
-    <MenuItem onClick={handleClose}>
-      <Link
-        target="_blank"
-        underline="none"
-        href={prependDiscourseUrl("logout")}
-      >
-        {translate("profile.actions.logout")}
-      </Link>
+    <MenuItem onClick={onClickLogout}>
+      {translate("profile.actions.logout")}
     </MenuItem>
   </Menu>
 );
 
 type Props = {
   user: User,
+  service: SessionHandler,
 };
 
 type State = {
@@ -93,6 +89,7 @@ type State = {
 
 export class UserAvatarDropdown extends React.Component<Props, State> {
   static defaultProps = {
+    service: SessionService,
     user: {},
   };
 
@@ -111,7 +108,7 @@ export class UserAvatarDropdown extends React.Component<Props, State> {
           color="inherit"
           aria-owns={anchorEl ? DROPDOWN_NAME : undefined}
           aria-haspopup="true"
-          onClick={this.handleClick}
+          onClick={this.toggle}
         >
           {avatarSrc ? (
             <Avatar
@@ -128,17 +125,24 @@ export class UserAvatarDropdown extends React.Component<Props, State> {
         <Dropdown
           anchorEl={anchorEl}
           handleClose={this.handleClose}
+          onClickLogout={this.onClickLogout}
           user={user}
         />
       </React.Fragment>
     );
   }
 
-  handleClick = (e: Event) => {
+  toggle = (e: Event) => {
     this.setState({ anchorEl: e.currentTarget });
   };
 
   handleClose = () => {
     this.setState({ anchorEl: null });
+  };
+
+  onClickLogout = () => {
+    const { user } = this.props;
+    this.props.service.logout(user.username);
+    this.handleClose();
   };
 }

--- a/src/profile/__tests__/UserAvatarDropdown.spec.js
+++ b/src/profile/__tests__/UserAvatarDropdown.spec.js
@@ -1,0 +1,33 @@
+// @flow
+
+import React from "react";
+import { UserAvatarDropdown } from "../UserAvatarDropdown";
+import { cleanup, fireEvent, render } from "react-testing-library";
+
+const service = {
+  getUser: jest.fn(),
+  login: jest.fn(),
+  logout: jest.fn(),
+  signup: jest.fn(),
+};
+
+const user = {
+  name: "Jane Doe",
+  username: "janedoe",
+};
+
+describe("<UserAvatarDropdown />", () => {
+  afterEach(cleanup);
+
+  it("handles a logout action after toggle", async () => {
+    const { getByText, getByLabelText } = render(
+      // $FlowFixMe
+      <UserAvatarDropdown service={service} user={user} />
+    );
+
+    fireEvent.click(getByLabelText(user.username));
+    fireEvent.click(getByText(/logout/i));
+
+    expect(service.logout).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/session/Session.js
+++ b/src/session/Session.js
@@ -33,12 +33,12 @@ export class Session extends React.Component<Props, State> {
 
   render() {
     const { user } = this.state;
-    const { children } = this.props;
+    const { children, service } = this.props;
 
     return user ? (
       children({ user })
     ) : (
-      <SessionActions onUserLoggedIn={this.updateUser} />
+      <SessionActions onLogin={service.login} onSignup={service.signup} />
     );
   }
 

--- a/src/session/Session.js
+++ b/src/session/Session.js
@@ -23,12 +23,7 @@ export class Session extends React.Component<Props, State> {
   };
 
   componentDidMount() {
-    window.addEventListener("focus", this.getUser);
     this.getUser();
-  }
-
-  componentWillUnmount() {
-    window.removeEventListener("focus", this.getUser);
   }
 
   render() {

--- a/src/session/SessionActions.js
+++ b/src/session/SessionActions.js
@@ -2,31 +2,22 @@
 
 import * as React from "react";
 import Button from "@material-ui/core/Button";
-import SessionService from "./SessionService";
 import { translate } from "../locales";
 
 type Props = {
-  service: SessionHandler,
+  onLogin: Function,
+  onSignup: Function,
 };
-export class SessionActions extends React.Component<Props> {
-  static defaultProps = {
-    service: SessionService,
-  };
 
-  render() {
-    return (
-      <div>
-        <Button color="inherit" onClick={this.createSession("login")}>
-          {translate("session.actions.login")}
-        </Button>
-        <Button color="inherit" onClick={this.createSession("signup")}>
-          {translate("session.actions.signup")}
-        </Button>
-      </div>
-    );
-  }
-
-  createSession = (action: "login" | "signup") => () => {
-    this.props.service[action]();
-  };
-}
+export const SessionActions = ({ onLogin, onSignup }: Props) => {
+  return (
+    <div>
+      <Button color="inherit" onClick={onLogin}>
+        {translate("session.actions.login")}
+      </Button>
+      <Button color="inherit" onClick={onSignup}>
+        {translate("session.actions.signup")}
+      </Button>
+    </div>
+  );
+};

--- a/src/session/SessionService.js
+++ b/src/session/SessionService.js
@@ -21,8 +21,19 @@ const getUser = async (): Promise<?User> => {
   }
 };
 
+const logout = async (username: string): Promise<boolean> => {
+  try {
+    await DiscourseService.reqDelete(`/session/${username}`);
+
+    return true;
+  } catch (error) {
+    return false;
+  }
+};
+
 export default {
   getUser,
   login,
+  logout,
   signup,
 };

--- a/src/session/SessionService.js
+++ b/src/session/SessionService.js
@@ -23,7 +23,11 @@ const getUser = async (): Promise<?User> => {
 
 const logout = async (username: string): Promise<boolean> => {
   try {
-    await DiscourseService.reqDelete(`session/${username}`);
+    await DiscourseService.reqDelete(`session/${username}`, {
+      // avoid fall error when trying to fetch redirected route after logout
+      redirect: "manual",
+    });
+    window.location.reload();
 
     return true;
   } catch (error) {

--- a/src/session/SessionService.js
+++ b/src/session/SessionService.js
@@ -23,7 +23,7 @@ const getUser = async (): Promise<?User> => {
 
 const logout = async (username: string): Promise<boolean> => {
   try {
-    await DiscourseService.reqDelete(`/session/${username}`);
+    await DiscourseService.reqDelete(`session/${username}`);
 
     return true;
   } catch (error) {

--- a/src/session/__tests__/Session.spec.js
+++ b/src/session/__tests__/Session.spec.js
@@ -3,7 +3,12 @@
 import "jest-dom/extend-expect";
 import React from "react";
 import { Session } from "../Session";
-import { cleanup, render, waitForElement } from "react-testing-library";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  waitForElement,
+} from "react-testing-library";
 
 describe("<Session />", () => {
   afterEach(() => {
@@ -13,14 +18,16 @@ describe("<Session />", () => {
   it("renders a set of actions to login and signup", () => {
     const service = {
       getUser: () => Promise.resolve(undefined),
-      login: () => undefined,
-      signup: () => undefined,
+      login: jest.fn(),
+      signup: jest.fn(),
     };
 
     const { getByText } = render(<Session service={service} />);
+    fireEvent.click(getByText(/signup/i));
+    fireEvent.click(getByText(/login/i));
 
-    expect(getByText(/signup/i)).toBeTruthy();
-    expect(getByText(/login/i)).toBeTruthy();
+    expect(service.login).toHaveBeenCalledTimes(1);
+    expect(service.signup).toHaveBeenCalledTimes(1);
   });
 
   describe("when service request is successfull", () => {
@@ -28,8 +35,8 @@ describe("<Session />", () => {
       const userData = { username: "John Doe" };
       const service = {
         getUser: () => Promise.resolve(userData),
-        login: () => undefined,
-        signup: () => undefined,
+        login: jest.fn(),
+        signup: jest.fn(),
       };
 
       const { getByText } = render(

--- a/src/session/__tests__/Session.spec.js
+++ b/src/session/__tests__/Session.spec.js
@@ -19,6 +19,7 @@ describe("<Session />", () => {
     const service = {
       getUser: () => Promise.resolve(undefined),
       login: jest.fn(),
+      logout: jest.fn().mockResolvedValue(true),
       signup: jest.fn(),
     };
 
@@ -36,6 +37,7 @@ describe("<Session />", () => {
       const service = {
         getUser: () => Promise.resolve(userData),
         login: jest.fn(),
+        logout: jest.fn().mockResolvedValue(true),
         signup: jest.fn(),
       };
 

--- a/src/session/__tests__/SessionService.spec.js
+++ b/src/session/__tests__/SessionService.spec.js
@@ -59,4 +59,30 @@ describe("SessionService", () => {
 
     expect(spy).toHaveBeenLastCalledWith("signup");
   });
+
+  describe("logout", () => {
+    it("return true when successful", done => {
+      const response = { ok: true, status: 200 };
+      DiscourseService.reqDelete = jest
+        .fn()
+        .mockImplementationOnce(() => Promise.resolve(response));
+
+      SessionService.logout("janedoe").then(result => {
+        expect(result).toBeTruthy();
+        done();
+      });
+    });
+
+    it("return false when error", done => {
+      const response = { ok: false, status: 500 };
+      DiscourseService.reqDelete = jest
+        .fn()
+        .mockImplementationOnce(() => Promise.reject(response));
+
+      SessionService.logout("janedoe").then(result => {
+        expect(result).toBeFalsy();
+        done();
+      });
+    });
+  });
 });

--- a/src/session/__tests__/SessionService.spec.js
+++ b/src/session/__tests__/SessionService.spec.js
@@ -63,12 +63,26 @@ describe("SessionService", () => {
   describe("logout", () => {
     it("return true when successful", done => {
       const response = { ok: true, status: 200 };
-      DiscourseService.reqDelete = jest
-        .fn()
-        .mockImplementationOnce(() => Promise.resolve(response));
+      const spyOnReload = jest
+        .spyOn(window.location, "reload")
+        .mockImplementation(jest.fn());
+      const spyOnRequest = jest
+        .spyOn(DiscourseService, "reqDelete")
+        .mockResolvedValueOnce(response);
 
       SessionService.logout("janedoe").then(result => {
+        expect(spyOnRequest.mock.calls[0]).toMatchInlineSnapshot(
+          `
+Array [
+  "session/janedoe",
+  Object {
+    "redirect": "manual",
+  },
+]
+`
+        );
         expect(result).toBeTruthy();
+        expect(spyOnReload).toBeCalledTimes(1);
         done();
       });
     });


### PR DESCRIPTION
**What:** Add logout action

**Why:** Closes #3 

We used to have a link with an invalid route and now we have a button to make a request to log out

**How:**
- Add support for proper DELETE request to `DiscourseService`
- Add logout action to `SessionService`
- Replace link by button action on `UserAvatarDropdown`

## Media
![http://recordit.co/edwS4DKEBN](http://recordit.co/edwS4DKEBN.gif)
---
_We have also updated to **remove on focus update of profile** (now users need to reload the app to see their information on the header) and **remove the need to refresh token before every request** (as we are not updating "live" the profile when reloading we will refresh the token)_