### PR TITLE
chore(renovate): add schedule to renovate bot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "extends": ["config:base"],
+  "schedule": ["before 11pm on Monday"],
   "packageRules": [
     {
       "packageNames": ["docz", "docz-theme-default"],


### PR DESCRIPTION
**What:** Set `schedule` for Renovate bot

**Why:** To only receive package update PRs on Mondays

**How:** https://renovatebot.com/docs/presets-schedule/
